### PR TITLE
Update aiwrapper package and agents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3347,13 +3347,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
-      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~7.12.0"
       }
     },
     "node_modules/@types/plist": {
@@ -4067,9 +4067,10 @@
       }
     },
     "node_modules/aiwrapper": {
-      "version": "2.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/aiwrapper/-/aiwrapper-2.0.0-alpha.1.tgz",
-      "integrity": "sha512-GEPkrFAyZeIJ+KRGDA3aZuneu3y87jNUeit/ZvzZEZsTHXAzb8B+GlAvdNGyuAlRrYphqh3E8LJw2/spkCPiTQ==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/aiwrapper/-/aiwrapper-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-ZRM3rrLEBJEyyllkHANN1N6IUquojx1pZtpcC1l0XAmeouerhothtib/jLoC2MQYCIduutUlAKIYmYNEL677vQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "aimodels": "^0.4.15",
@@ -12631,9 +12632,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -13619,10 +13620,11 @@
       "name": "@sila/core",
       "version": "1.0.0",
       "dependencies": {
-        "aiwrapper": "^2.0.0-alpha.1",
+        "aiwrapper": "^2.0.0-alpha.2",
         "reptree": "^0.2.3"
       },
       "devDependencies": {
+        "@types/node": "^24.5.2",
         "typescript": "~5.8.3"
       }
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,10 +10,11 @@
     "watch": "tsc -p tsconfig.json --noEmit --watch"
   },
   "dependencies": {
-    "aiwrapper": "^2.0.0-alpha.1",
+    "aiwrapper": "^2.0.0-alpha.2",
     "reptree": "^0.2.3"
   },
   "devDependencies": {
+    "@types/node": "^24.5.2",
     "typescript": "~5.8.3"
   }
 }

--- a/packages/core/src/agents/SimpleChatAgent.ts
+++ b/packages/core/src/agents/SimpleChatAgent.ts
@@ -1,4 +1,4 @@
-import type { LangChatMessage, LangContentPart } from "aiwrapper";
+import type { LangMessage, LangContentPart } from "aiwrapper";
 import { FileReference, FileResolver } from "../spaces/files/FileResolver";
 import { AppConfig, ThreadMessage } from "../models";
 import { Agent, AgentInput, AgentOutput } from "./Agent";
@@ -59,7 +59,7 @@ export class SimpleChatAgent extends Agent<AppConfigForChat> {
       return { base64: dataUrl };
     }
 
-    const remappedMessages: LangChatMessage[] = [
+    const remappedMessages: LangMessage[] = [
       { role: "system", content: systemPrompt },
       ...await Promise.all(messages.map(async (m) => {
         // Validate and normalize the role - only allow "assistant" or "user"
@@ -73,7 +73,7 @@ export class SimpleChatAgent extends Agent<AppConfigForChat> {
           return {
             role: normalizedRole as "assistant" | "user",
             content: m.text || "",
-          } as LangChatMessage;
+          } as LangMessage;
         }
 
         const fileRefs = (m as any).files as Array<FileReference>;
@@ -106,7 +106,7 @@ export class SimpleChatAgent extends Agent<AppConfigForChat> {
             parts.push({ type: 'image', image: { kind: 'base64', base64, mimeType } });
           }
           
-          return { role: normalizedRole as "assistant" | "user", content: parts } as LangChatMessage;
+          return { role: normalizedRole as "assistant" | "user", content: parts } as LangMessage;
         }
 
         // Handle text-only content (no images or non-vision models)
@@ -130,7 +130,7 @@ export class SimpleChatAgent extends Agent<AppConfigForChat> {
         return {
           role: normalizedRole as "assistant" | "user",
           content: content,
-        } as LangChatMessage;
+        } as LangMessage;
       })),
     ];
 


### PR DESCRIPTION
Update `aiwrapper` package to `2.0.0-alpha.2` and address breaking API changes.

The `aiwrapper` update introduced a breaking change where `LangChatMessage` was renamed to `LangMessage`, requiring updates in `SimpleChatAgent.ts`. Additionally, `@types/node` was added to resolve unrelated compilation errors encountered during the update process.

---
<a href="https://cursor.com/background-agent?bcId=bc-73e10f35-1196-46ff-8647-09f027c95605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-73e10f35-1196-46ff-8647-09f027c95605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

