### PR TITLE
Add deb package build support

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -53,6 +53,10 @@
         {
           "target": "AppImage",
           "arch": ["x64", "arm64"]
+        },
+        {
+          "target": "deb",
+          "arch": ["x64", "arm64"]
         }
       ]
     }


### PR DESCRIPTION
Add `.deb` target to Linux build configuration to support building `.deb` packages alongside AppImage.

---
<a href="https://cursor.com/background-agent?bcId=bc-11909c8b-7a37-435f-983e-f2c9aab8d1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-11909c8b-7a37-435f-983e-f2c9aab8d1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

