### PR TITLE
Import chatgpt chats into sila workspace

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,7 +30,8 @@
     "@markpage/svelte": "^0.1.1",
     "socket.io-client": "^4.8.1",
     "svelte-persisted-store": "^0.12.0",
-    "ttabs-svelte": "^0.0.13"
+    "ttabs-svelte": "^0.0.13",
+    "chatgpt-export-parser": "^0.3.2"
   },
   "devDependencies": {
     "@skeletonlabs/skeleton": "^3.1.2",

--- a/packages/client/src/lib/swins/routes/Settings.svelte
+++ b/packages/client/src/lib/swins/routes/Settings.svelte
@@ -11,6 +11,7 @@
   } from "@sila/core";
   import { txtStore } from "@sila/client/state/txtStore";
   import ThemeSwitcher from "@sila/client/comps/themes/ThemeSwitcher.svelte";
+  import { importChatGptZipIntoSpace } from "@sila/client/utils/chatgptImport";
 </script>
 
 <div>
@@ -48,6 +49,30 @@
     <div class="card p-4 border-[1px] border-surface-200-800">
       <h3 class="h4 mb-4">{$txtStore.settingsPage.providers.title}</h3>
       <ModelProviders />
+    </div>
+
+    <div class="card p-4 border-[1px] border-surface-200-800">
+      <h3 class="h4 mb-4">Import from ChatGPT</h3>
+      <div class="flex items-center gap-3">
+        <input id="chatgptZipInput" type="file" accept="application/zip" class="input" onchange={async (e: any) => {
+          try {
+            const file = e?.currentTarget?.files?.[0];
+            if (!file) return;
+            if (!clientState.currentSpace) {
+              alert("No active workspace selected.");
+              return;
+            }
+            const res = await importChatGptZipIntoSpace(clientState.currentSpace, file);
+            alert(`Imported: ${res.created}, Skipped: ${res.skipped}`);
+          } catch (err) {
+            console.error(err);
+            alert("Failed to import ChatGPT export. Check console for details.");
+          } finally {
+            e.currentTarget.value = '';
+          }
+        }} />
+      </div>
+      <p class="text-sm mt-2 opacity-70">Select your ChatGPT export .zip. We will create conversations and attachments. Duplicates are skipped using ChatGPT conversation id.</p>
     </div>
 
     <div class="card p-4 border-[1px] border-surface-200-800">

--- a/packages/client/src/lib/types/ambient.d.ts
+++ b/packages/client/src/lib/types/ambient.d.ts
@@ -1,0 +1,2 @@
+declare module 'chatgpt-export-parser';
+declare module '@sila/core';

--- a/packages/client/src/lib/utils/chatgptImport.ts
+++ b/packages/client/src/lib/utils/chatgptImport.ts
@@ -1,0 +1,139 @@
+// We avoid static imports to prevent tooling resolution issues in some environments
+// and load peer package code dynamically at runtime.
+
+// Lazy import parser to avoid bloating initial bundle
+async function loadParser(): Promise<any> {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return await import("chatgpt-export-parser");
+}
+
+type ParsedAttachment = {
+  name?: string;
+  mimeType?: string;
+  size?: number;
+  dataUrl?: string;
+  content?: string;
+};
+
+type ParsedMessage = {
+  role: "user" | "assistant" | "system";
+  text?: string;
+  createdAt?: number | string;
+  attachments?: ParsedAttachment[];
+  files?: ParsedAttachment[]; // alternate field name
+};
+
+type ParsedConversation = {
+  id: string; // ChatGPT conversation id
+  title?: string;
+  messages: ParsedMessage[];
+};
+
+export type ImportResult = {
+  created: number;
+  skipped: number;
+  updated: number;
+};
+
+function findExistingChatByChatgptId(space: any, chatgptId: string): any | undefined {
+  const refIds: string[] = space.getAppTreeIds();
+  for (const refId of refIds) {
+    const refVertex = space.getVertex(refId);
+    if (!refVertex) continue;
+    const existingId = refVertex.getProperty("chatgptId") as string | undefined;
+    if (existingId !== chatgptId) continue;
+    const tid = refVertex.getProperty("tid") as string | undefined;
+    if (!tid) continue;
+    const appTree = space.getAppTree(tid);
+    if (appTree) return appTree;
+  }
+  return undefined;
+}
+
+type LocalAttachmentPreview = {
+  id: string;
+  kind: 'image' | 'text' | 'file';
+  name: string;
+  mimeType: string;
+  size: number;
+  dataUrl?: string;
+  content?: string;
+};
+
+function toAttachmentPreview(att: ParsedAttachment): LocalAttachmentPreview {
+  const id = (globalThis.crypto && "randomUUID" in globalThis.crypto)
+    ? globalThis.crypto.randomUUID()
+    : Math.random().toString(36).slice(2);
+  const name = att.name ?? "file";
+  const mimeType = att.mimeType ?? (att.dataUrl?.split(":")[1]?.split(";")[0] ?? "application/octet-stream");
+  const size = att.size ?? 0;
+  const kind: LocalAttachmentPreview["kind"] = att.dataUrl ? "image" : att.content ? "text" : "file";
+  const preview: LocalAttachmentPreview = {
+    id,
+    kind,
+    name,
+    mimeType,
+    size,
+  };
+  if (att.dataUrl) preview.dataUrl = att.dataUrl;
+  if (att.content) preview.content = att.content;
+  return preview;
+}
+
+export async function importChatGptZipIntoSpace(space: any, zipFile: File): Promise<ImportResult> {
+  const parser: any = await loadParser();
+  const core: any = await import("@sila/core");
+  // Try common entry points
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const parsed: { conversations: ParsedConversation[] } = await (
+    parser.parseZip ? parser.parseZip(zipFile)
+    : parser.parse ? parser.parse(zipFile)
+    : parser.default ? parser.default(zipFile)
+    : Promise.reject(new Error("chatgpt-export-parser: no parse function found"))
+  );
+
+  let created = 0;
+  let skipped = 0;
+  let updated = 0;
+
+  for (const conv of parsed.conversations || []) {
+    if (!conv?.id) continue;
+    const existing = findExistingChatByChatgptId(space, conv.id);
+    if (existing) {
+      // v1: skip updates
+      skipped += 1;
+      continue;
+    }
+
+    const appTree = core.ChatAppData.createNewChatTree(space, "default");
+    const chatData = new core.ChatAppData(space, appTree);
+    chatData.title = conv.title || "Imported chat";
+
+    // Mark identifiers for duplicate detection
+    const root = appTree.tree.root!;
+    root.setProperty("chatgptId", conv.id);
+    const refVertex = space.getVertexReferencingAppTree(appTree.getId());
+    if (refVertex) {
+      refVertex.setProperty("chatgptId", conv.id);
+    }
+
+    for (const m of conv.messages || []) {
+      const role = m.role === "assistant" ? "assistant" : "user"; // ignore system for v1
+      const text = m.text || "";
+      const rawAtts = (m.attachments && m.attachments.length > 0)
+        ? m.attachments
+        : (m.files && m.files.length > 0)
+        ? m.files
+        : [];
+      const mapped = rawAtts.length > 0 ? rawAtts.map(toAttachmentPreview) : [];
+      const onlySupported = mapped.filter(a => !!a.dataUrl || !!a.content);
+      const attachments = onlySupported.length > 0 ? onlySupported : undefined;
+      await chatData.newMessage(role, text, undefined, attachments);
+    }
+
+    created += 1;
+  }
+
+  return { created, skipped, updated };
+}
+


### PR DESCRIPTION
Add ChatGPT export ZIP importer to settings to allow users to import conversations and attachments into the current workspace.

This PR introduces a new "Import from ChatGPT" section in the Settings page. It uses the `chatgpt-export-parser` package to process a user-provided ChatGPT export ZIP file, creating new chat trees and messages in the active workspace. Each imported conversation is tagged with its original ChatGPT ID to prevent duplicates on subsequent imports.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ad42807-0fc5-400a-92c2-f67ff89d08f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ad42807-0fc5-400a-92c2-f67ff89d08f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

